### PR TITLE
Added linked users route

### DIFF
--- a/app/Http/Requests/LegacyApiRequest.php
+++ b/app/Http/Requests/LegacyApiRequest.php
@@ -12,6 +12,14 @@ class LegacyApiRequest extends BaseRequest
             'user' => 'required|string',
         ];
     }
+
+    public function getLinkedUsersData(): array
+    {
+        return [
+            'user' => 'required|string',
+        ];
+    }
+
     public function setAccountType(): array
     {
         return [
@@ -19,6 +27,7 @@ class LegacyApiRequest extends BaseRequest
             'type' => 'required|string|in:'.collect(AccountType::cases())->pluck('value')->implode(','),
         ];
     }
+
     public function updateCosmetics(): array
     {
         return [
@@ -32,6 +41,7 @@ class LegacyApiRequest extends BaseRequest
             'cosmetics.parts.ears' => 'boolean',
         ];
     }
+
     public function setGuildColor(): array
     {
         return [
@@ -39,6 +49,7 @@ class LegacyApiRequest extends BaseRequest
             'color' => 'required|string|regex:/^#[0-9a-fA-F]{6}$/|max:7|min:7|unique:guilds,color',
         ];
     }
+
     public function setUserPassword(): array
     {
         return [
@@ -46,6 +57,7 @@ class LegacyApiRequest extends BaseRequest
             'password' => 'required|string',
         ];
     }
+
     public function getUserByPassword(): array
     {
         return [
@@ -53,6 +65,7 @@ class LegacyApiRequest extends BaseRequest
             'password' => 'required|string',
         ];
     }
+
     public function getUserConfig(): array
     {
         return [
@@ -60,4 +73,5 @@ class LegacyApiRequest extends BaseRequest
             'configName' => 'required|string',
         ];
     }
+
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\LegacyApiController;
 
 Route::controller(LegacyApiController::class)->middleware('athena.token')->group(static function () {
     Route::post('getUser/{apiKey}', 'getUserData');
+    Route::post('getLinkedUsers/{apiKey}', 'getLinkedUsersData');
     Route::post('getUserConfig/{apiKey}', 'getUserConfig');
     Route::post('setAccountType/{apiKey}', 'setAccountType');
     Route::post('updateCosmetics/{apiKey}', 'updateCosmetics');


### PR DESCRIPTION
Many players have more than one account, while the normal `getUser` route only returns a single user object. Goal of this PR is to add a route that returns all user objects matching the given UUID (will only be one, but nice to have for same interface with `getUser`), Minecraft name, or Discord ID.

Use cases:  
- checking Minecraft accounts of a Patreon supporter
- checking Minecraft accounts before guild colour changes