### PR TITLE
Fix gear viewer ID translation

### DIFF
--- a/app/Http/Libraries/ItemManager.php
+++ b/app/Http/Libraries/ItemManager.php
@@ -211,10 +211,10 @@ class ItemManager
         $result['INTELLIGENCEPOINTS'] = 'rawIntelligence';
         $result['DEFENSEPOINTS'] = 'rawDefence';
         $result['AGILITYPOINTS'] = 'rawAgility';
-        $result['MAINATTACKDAMAGEBONUS'] = 'mainAttackDamage';
-        $result['MAINATTACKDAMAGEBONUSRAW'] = 'rawMainAttackDamage';
-        $result['SPELLDAMAGEBONUS'] = 'spellDamage';
-        $result['SPELLDAMAGEBONUSRAW'] = 'rawSpellDamage';
+        $result['DAMAGEBONUS'] = 'mainAttackDamage';
+        $result['AMAGEBONUSRAW'] = 'rawMainAttackDamage';
+        $result['SPELLDAMAGE'] = 'spellDamage';
+        $result['SPELLDAMAGERAW'] = 'rawSpellDamage';
         $result['HEALTHREGEN'] = 'healthRegen';
         $result['HEALTHREGENRAW'] = 'rawHealthRegen';
         $result['HEALTHBONUS'] = 'rawHealth';


### PR DESCRIPTION
Updates the list of IDs used in the gear viewer to reflect the new internal names of spell/main attack stats