### PR TITLE
refactor: add filter to guild list route

### DIFF
--- a/app/Http/Controllers/GuildController.php
+++ b/app/Http/Controllers/GuildController.php
@@ -7,8 +7,12 @@ use Illuminate\Http\Request;
 class GuildController extends Controller {
 
 
-    public function list() {
-        return Guild::all()->toArray();
+    public function list($filter) {
+        if($filter === "all") {
+            return Guild::all()->toArray();
+        } else {
+            return Guild::where('color', '!=', '')->get()->toArray();
+        }
     }
     public function setColor(Request $request)
     {

--- a/app/Http/Controllers/GuildController.php
+++ b/app/Http/Controllers/GuildController.php
@@ -10,9 +10,9 @@ class GuildController extends Controller {
     public function list($filter) {
         if($filter === "all") {
             return Guild::all()->toArray();
-        } else {
-            return Guild::where('color', '!=', '')->get()->toArray();
         }
+
+        return Guild::where('color', '!=', '')->get()->toArray();
     }
     public function setColor(Request $request)
     {

--- a/routes/api/guilds.php
+++ b/routes/api/guilds.php
@@ -3,6 +3,6 @@
 use \App\Http\Controllers\GuildController;
 
 Route::controller(GuildController::class)->group(static function() {
-   Route::get('list', 'list')->name('list');
+   Route::get('list/{filter?}', 'list')->name('list');
    Route::post('setColor/{apiKey}', 'setColor')->middleware(['athena.token'])->name('setColor');
 });


### PR DESCRIPTION
Adds an optional filter parameter to the list route

`all` - Returns every guild saved
If the parameter is not given it'll only return the guilds with a set color.