### PR TITLE
fix: version controller returning for wrong mcVersion

### DIFF
--- a/app/Http/Controllers/VersionController.php
+++ b/app/Http/Controllers/VersionController.php
@@ -63,7 +63,7 @@ class VersionController extends Controller
             return response()->json(['error' => 'No release found for this stream'], 404);
         }
 
-        $mcVersion = (string) ($mcVersion ?? 'unknown');
+        $mcVersion = $mcVersion ?? 'unknown';
 
         $cache = \Cache::get('version', []);
 

--- a/app/Http/Controllers/VersionController.php
+++ b/app/Http/Controllers/VersionController.php
@@ -63,15 +63,18 @@ class VersionController extends Controller
             return response()->json(['error' => 'No release found for this stream'], 404);
         }
 
+        $mcVersion = (string) ($mcVersion ?? 'unknown');
+
         $cache = \Cache::get('version', []);
+
         if (
-            !isset($cache[$stream][$client])
-            || $cache[$stream][$client]['tag'] !== $latest['tag_name']
-            || !is_array($cache[$stream][$client]['md5'])
-            || empty($cache[$stream][$client]['md5'])
+            !isset($cache[$stream][$mcVersion][$client])
+            || $cache[$stream][$mcVersion][$client]['tag'] !== $latest['tag_name']
+            || !is_array($cache[$stream][$mcVersion][$client]['md5'])
+            || empty($cache[$stream][$mcVersion][$client]['md5'])
         ) {
-            $cache[$stream][$client] = [];
-            $cache = $this->updateCache($cache, $stream, $client, $latest);
+            $cache[$stream][$mcVersion][$client] = [];
+            $cache = $this->updateCache($cache, $stream, $mcVersion, $client, $latest);
         }
 
         // We need to filter the asset list to only the current modloader if we're using Artemis
@@ -92,7 +95,7 @@ class VersionController extends Controller
         $response = [
             'version' => $latestTag,
             'url' => $asset['browser_download_url'],
-            'md5' => $cache[$stream][$client]['md5'][$asset['name']],
+            'md5' => $cache[$stream][$mcVersion][$client]['md5'][$asset['name']],
             'changelog' => route('version.changelog', [$latest['tag_name']]),
         ];
 
@@ -328,7 +331,7 @@ class VersionController extends Controller
         });
     }
 
-    private function updateCache(mixed $cache, $stream, string $client, mixed $latest)
+    private function updateCache(mixed $cache, $stream, string $mcVersion, string $client, mixed $latest)
     {
         $md5 = [];
 
@@ -336,7 +339,7 @@ class VersionController extends Controller
             $md5[$asset['name']] = md5_file($asset['browser_download_url']);
         }
 
-        $cache[$stream][$client] = [
+        $cache[$stream][$mcVersion][$client] = [
             'tag' => $latest['tag_name'],
             'md5' => $md5,
         ];

--- a/app/Http/Middleware/BlockUserAgents.php
+++ b/app/Http/Middleware/BlockUserAgents.php
@@ -34,7 +34,7 @@ class BlockUserAgents
 
         foreach($this->blockedUserAgents as $blockedUserAgent) {
             if(stripos($userAgent, $blockedUserAgent) !== false) {
-                return response('This user agent is blocked', 403);
+                response()->json(['error' => 'This user-agent is blocked'], 403)->throwResponse();
             }
         }
 

--- a/app/Http/Middleware/BlockUserAgents.php
+++ b/app/Http/Middleware/BlockUserAgents.php
@@ -34,7 +34,7 @@ class BlockUserAgents
 
         foreach($this->blockedUserAgents as $blockedUserAgent) {
             if(stripos($userAgent, $blockedUserAgent) !== false) {
-                response()->json(['error' => 'This user-agent is blocked'], 403)->throwResponse();
+                return response('This user agent is blocked', 403);
             }
         }
 

--- a/tests/Feature/VersionControllerTest.php
+++ b/tests/Feature/VersionControllerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Str;
+use Tests\TestCase;
+use Tests\Unit\AssertableJson;
+
+class VersionControllerTest extends TestCase
+{
+    /**
+     * Tests if the version controller returns the latest version for the right minecraft version
+     *
+     * @return void
+     */
+    public function test_is_right_minecraft_version(): void
+    {
+
+        $userAgent = "Wynntils Artemis\\v2.4.10-beta.71+MC-1.21.4 (client) FABRIC";
+        $mcVersion = Str::after($userAgent, '+MC-');
+        $mcVersion = Str::before($mcVersion, ' ');
+
+        $response = $this->withHeaders([
+            'User-Agent' => $userAgent,
+        ])->getJson('/version/latest/release');
+
+        $response->assertJson([
+            'supportedMcVersion' => $mcVersion,
+            ]);
+    }
+}


### PR DESCRIPTION
This should fix the issue where it caches v2.4.18 as a valid version for 1.21.4