### PR TITLE
fix: disable the patreon update command schedule for now

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -15,7 +15,8 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-         $schedule->command('patreon:update')->daily();
+         // TODO: Fix this patreon update command
+         // $schedule->command('patreon:update')->daily();
     }
 
     /**


### PR DESCRIPTION
Disables the scheduled patreon update command for now. API key probably needs updating/command needs fixing as a whole.

Need access to logs to fully see whats happening