### PR TITLE
fix: resolve #62 mcVersion strict-match regression

### DIFF
--- a/app/Http/Controllers/VersionController.php
+++ b/app/Http/Controllers/VersionController.php
@@ -21,9 +21,9 @@ class VersionController extends Controller
         $dev = $userAgent->contains('dev');
         $modloader = $mcVersion = null;
 
-        $modloader = $this->normalizeModloader($userAgent->afterLast(' '));
+        $modloader = $this->normalizeModloader((string) $userAgent->afterLast(' '));
         if ($userAgent->contains('+')) {
-            $mcVersion = $userAgent->upper()->after('+MC-')->before(' ');
+            $mcVersion = (string) $userAgent->upper()->after('+MC-')->before(' ');
         }
 
         return [
@@ -45,8 +45,10 @@ class VersionController extends Controller
             'stream' => $userAgentStream,
         ] = $this->userAgentDetails($request);
 
+        $requestedMcVersion = $mcVersion ? strtolower((string) $mcVersion) : null;
+
         $stream = $this->resolveLatestStream($stream, $userAgentStream);
-        $releases = $this->getReleases($client, $stream, 1, $mcVersion ?? null);
+        $releases = $this->getReleases($client, $stream, 1, $requestedMcVersion);
 
         $latest = $releases->first(function ($release) {
             return !empty($release['assets']); // Filter out releases without assets
@@ -57,9 +59,8 @@ class VersionController extends Controller
                 ->header('Vary', 'User-Agent');
         }
 
-        $requestedMcVersion = $mcVersion;
-        $mcVersion = (string) ($mcVersion ?? 'unknown');
-        $assetMd5 = $this->getCachedAssetMd5($client, $stream, $mcVersion, $latest);
+        $cacheMcVersion = (string) ($requestedMcVersion ?? 'unknown');
+        $assetMd5 = $this->getCachedAssetMd5($client, $stream, $cacheMcVersion, $latest);
 
         $asset = collect($latest['assets'])->first(function ($asset) use ($modloader, $requestedMcVersion) {
             $name = str($asset['name']);
@@ -91,7 +92,7 @@ class VersionController extends Controller
 
 
         if (str($asset['name'])->contains('+MC-')) {
-            $tagMcVersion = str($asset['name'])->after('+MC-')->before('.jar');
+            $tagMcVersion = (string) str($asset['name'])->after('+MC-')->before('.jar');
             $response['supportedMcVersion'] = $tagMcVersion;
         }
 
@@ -163,7 +164,7 @@ class VersionController extends Controller
             return null;
         }
 
-        return $matches[1];
+        return strtolower($matches[1]);
     }
 
     private function userAgentStream(string $userAgent): string
@@ -295,8 +296,10 @@ class VersionController extends Controller
             // the +MC- prefix is used to indicate that the release is for a specific mcVersion
             // this prefix is found in the assets name
             if ($mcVersion) {
-                $assets = collect($release['assets'])->filter(function ($asset) use ($mcVersion) {
-                    return $this->assetMinecraftVersion($asset['name']) === $mcVersion;
+                $requestedMcVersion = strtolower((string) $mcVersion);
+
+                $assets = collect($release['assets'])->filter(function ($asset) use ($requestedMcVersion) {
+                    return $this->assetMinecraftVersion($asset['name']) === $requestedMcVersion;
                 });
                 if ($assets->isEmpty()) {
                     return false;


### PR DESCRIPTION
## Summary
Follow-up fix for the regression introduced after #62 merge (`No release found for this stream` on fresh requests).

## Why this fixes the issue
The failure point appears at:

```php
$latest = $releases->first(...)
```

but that is only the **symptom**.

The actual root cause happens earlier:
- #62 switched matching to strict equality (`===`) for mcVersion checks.
- `userAgentDetails()` extracts `$mcVersion` via Laravel `str(...)->after(...)->before(...)`, which yields a `Stringable` value unless cast.
- strict comparisons like
  - `assetMinecraftVersion(...) === $requestedMcVersion`
  - `assetMinecraftVersion(...) === $mcVersion`
  can fail due to type mismatch (`string` vs `Stringable`) even when textual values are identical.
- That empties release candidates, so `$latest` becomes null.

So we fix at the source (normalization boundary), not the symptom line.

## Changes
- Normalize/cast UA-derived values to plain strings before strict comparisons:
  - Cast `modloader` and `mcVersion` in `userAgentDetails()`.
  - Normalize requested mcVersion in `latest()` (`strtolower((string) ...)`).
  - Normalize mcVersion in `getReleases()` before asset filtering.
- Normalize extracted asset mc version to lowercase in `assetMinecraftVersion()`.
- Keep #62 cache-control behavior untouched.

## Effect
- Preserves exact mcVersion matching from #62 (no substring false positives).
- Restores valid release selection for `1.21.4` and `1.21.11` requests.
