### PR TITLE
perf: optimize user.getInfoLegacy with cache invalidation, cape texture cache, and ETags

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -123,7 +123,7 @@ class UserController extends Controller
     private function getUser($user): User
     {
         $user = Cache::remember("user-{$user}", 3600, function () use ($user) {
-            return User::where('id', $user)->first();
+            return User::find($user);
         });
 
         if (! $user) {

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -7,11 +7,12 @@ use App\Http\Requests\UserRequest;
 use App\Http\Resources\UserResource;
 use App\Models\User;
 use Auth;
+use Dedoc\Scramble\Attributes\ExcludeRouteFromDocs;
 use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Cache;
-use Dedoc\Scramble\Attributes\ExcludeRouteFromDocs;
+
 #[Group('User')]
 class UserController extends Controller
 {
@@ -106,17 +107,22 @@ class UserController extends Controller
     /**
      * Get user account type and cosmetics
      */
-    public function getInfoPost(UserRequest $request): UserResource
+    public function getInfoPost(UserRequest $request): UserResource|\Illuminate\Http\JsonResponse|\Illuminate\Http\Response
     {
         $user = $this->getUser($request->validated('uuid'));
 
-        return new UserResource($user);
+        $etag = md5($user->account_type->value.json_encode($user->cosmetic_info));
+
+        if ($request->header('If-None-Match') === $etag) {
+            return response('', 304);
+        }
+
+        return (new UserResource($user))->response()->header('ETag', $etag);
     }
 
     private function getUser($user): User
     {
-        // -- TTL 10 min
-        $user = Cache::remember("user-{$user}", 600, function () use ($user) {
+        $user = Cache::remember("user-{$user}", 3600, function () use ($user) {
             return User::where('id', $user)->first();
         });
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -111,7 +111,7 @@ class UserController extends Controller
     {
         $user = $this->getUser($request->validated('uuid'));
 
-        $etag = md5($user->account_type->value.json_encode($user->cosmetic_info));
+        $etag = '"'.md5($user->account_type->value.json_encode($user->cosmetic_info)).'"';
 
         if ($request->header('If-None-Match') === $etag) {
             return response('', 304);

--- a/app/Http/Libraries/CapeManager.php
+++ b/app/Http/Libraries/CapeManager.php
@@ -178,6 +178,9 @@ class CapeManager
         $this->approved->put($capeId, $this->queue->get($capeId));
         $this->queue->delete($capeId);
 
+        Cache::forget("cape-texture-{$capeId}-1");
+        Cache::forget("cape-texture-{$capeId}-0");
+
         Notifications::cape(
             title: 'A cape was approved',
             description: "➡️ **SHA-1**: $capeId",
@@ -199,6 +202,9 @@ class CapeManager
 
         $this->banned->put($capeId, $this->getCape($capeId));
         $this->deleteCape($capeId);
+
+        Cache::forget("cape-texture-{$capeId}-1");
+        Cache::forget("cape-texture-{$capeId}-0");
 
         Notifications::cape(
             title: 'A cape was banned',

--- a/app/Http/Libraries/CapeManager.php
+++ b/app/Http/Libraries/CapeManager.php
@@ -6,6 +6,7 @@ use App\Enums\MaskType;
 use App\Http\Traits\Singleton;
 use Carbon\Carbon;
 use DiscordWebhook\EmbedColor;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
 use Imagick;
 use Intervention\Image\Facades\Image as ImageFactory;
@@ -16,21 +17,25 @@ class CapeManager
     // TODO: If special cape doesn't exist, fallback on the users cape, also a setting to toggle this on the website.
     // array for special occasions on specific dates
     private array $specialCapes = [
-        //'01-01' => 'newYears',
-        //'04-01' => 'aprilFools',
-        //'07-04' => 'independenceDay',
+        // '01-01' => 'newYears',
+        // '04-01' => 'aprilFools',
+        // '07-04' => 'independenceDay',
         // '10-31' => 'halloween',
-        //'12-24' => 'christmasEve',
+        // '12-24' => 'christmasEve',
         // '12-25' => 'christmas',
-        //'12-31' => 'newYearsEve',
+        // '12-31' => 'newYearsEve',
     ];
 
     use Singleton;
 
     private \Illuminate\Contracts\Filesystem\Filesystem $queue;
+
     private \Illuminate\Contracts\Filesystem\Filesystem $banned;
+
     private \Illuminate\Contracts\Filesystem\Filesystem $approved;
+
     private \Illuminate\Contracts\Filesystem\Filesystem $special;
+
     private string $token;
 
     public function __construct()
@@ -89,21 +94,27 @@ class CapeManager
             return base64_encode($this->getSpecialCape());
         }
 
-        if($omitDefaultCape) {
-            return base64_encode($this->approved->get($capeId));
-        }
+        $cacheKey = 'cape-texture-'.$capeId.'-'.($omitDefaultCape ? '1' : '0');
 
-        return base64_encode($this->approved->get($capeId) ?? $this->special->get('defaultCape'));
+        return Cache::remember($cacheKey, 2592000, function () use ($capeId, $omitDefaultCape) {
+            if ($omitDefaultCape) {
+                return base64_encode($this->approved->get($capeId));
+            }
+
+            return base64_encode($this->approved->get($capeId) ?? $this->special->get('defaultCape'));
+        });
     }
 
     public function listCapes(): array
     {
         ini_set('memory_limit', '-1');
+
         return collect($this->approved->files())->filter(static function ($item) {
             return $item !== '.gitignore';
         })->map(function ($item) {
             try {
                 $image = ImageFactory::make($this->approved->path($item));
+
                 return ['sha' => $item, 'width' => $image->getWidth(), 'height' => $image->getHeight()];
             } catch (\Throwable $e) {
                 return ['sha' => $item, 'width' => 0, 'height' => 0];
@@ -125,7 +136,7 @@ class CapeManager
 
     public function getSha(Image $image): string
     {
-        $imagick = new Imagick();
+        $imagick = new Imagick;
 
         $image->encode('png');
 
@@ -142,7 +153,7 @@ class CapeManager
 
         if ($notify) {
             Notifications::cape(
-                title: "A new cape needs approval!",
+                title: 'A new cape needs approval!',
                 description: sprintf("**Uploaded by:** %s\n➡️ **Choose:** [Approve Full](%s) / [Approve Cape](%s) / [Approve Elytra](%s) or [Ban](%s)\n**SHA-1:** %s",
                     $username,
                     route('capes.queue.approve', ['token' => $this->token, 'sha' => $capeId, 'type' => 'full']),
@@ -160,7 +171,7 @@ class CapeManager
 
     public function approveCape(string $capeId): void
     {
-        if (!$this->isQueued($capeId)) {
+        if (! $this->isQueued($capeId)) {
             return;
         }
 
@@ -168,7 +179,7 @@ class CapeManager
         $this->queue->delete($capeId);
 
         Notifications::cape(
-            title: "A cape was approved",
+            title: 'A cape was approved',
             description: "➡️ **SHA-1**: $capeId",
             color: EmbedColor::GREEN,
             imageUrl: url("capes/get/$capeId")
@@ -190,7 +201,7 @@ class CapeManager
         $this->deleteCape($capeId);
 
         Notifications::cape(
-            title: "A cape was banned",
+            title: 'A cape was banned',
             description: "➡️ **SHA-1**: $capeId",
             color: EmbedColor::RED,
             imageUrl: url("capes/queue/get/$capeId")
@@ -217,14 +228,14 @@ class CapeManager
 
         $mask = ImageFactory::make($maskImage);
 
-        if(
+        if (
             $mask->width() !== $image->width()
             && $mask->height() !== $image->height()
         ) {
             $mask->resize($image->width(), $image->width() / 2);
         }
 
-        if($image->height() !== $image->width() / 2) {
+        if ($image->height() !== $image->width() / 2) {
             $mask = ImageFactory::canvas($image->width(), $image->height())->fill($mask);
         }
 

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+
+class UserObserver
+{
+    /**
+     * Handle the User "updated" event.
+     */
+    public function updated(User $user): void
+    {
+        if (! $user->isDirty(['account_type', 'cosmetic_info'])) {
+            return;
+        }
+
+        Cache::forget("user-{$user->id}");
+
+        $oldCosmeticInfo = $user->getOriginal('cosmetic_info') ?? [];
+        $oldTexture = $oldCosmeticInfo['capeTexture'] ?? 'defaultCape';
+
+        Cache::forget("cape-texture-{$oldTexture}-1");
+        Cache::forget("cape-texture-{$oldTexture}-0");
+    }
+}

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -18,10 +18,12 @@ class UserObserver
 
         Cache::forget("user-{$user->id}");
 
-        $oldCosmeticInfo = $user->getOriginal('cosmetic_info') ?? [];
-        $oldTexture = $oldCosmeticInfo['capeTexture'] ?? 'defaultCape';
+        if ($user->isDirty('cosmetic_info')) {
+            $oldCosmeticInfo = $user->getOriginal('cosmetic_info') ?? [];
+            $oldTexture = $oldCosmeticInfo['capeTexture'] ?? 'defaultCape';
 
-        Cache::forget("cape-texture-{$oldTexture}-1");
-        Cache::forget("cape-texture-{$oldTexture}-0");
+            Cache::forget("cape-texture-{$oldTexture}-1");
+            Cache::forget("cape-texture-{$oldTexture}-0");
+        }
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,8 @@
 namespace App\Providers;
 
 use App\Http\Extensions\SecurityOperationExtension;
+use App\Models\User;
+use App\Observers\UserObserver;
 use Dedoc\Scramble\Scramble;
 use Dedoc\Scramble\Support\Generator\OpenApi;
 use Dedoc\Scramble\Support\Generator\SecurityScheme;
@@ -54,6 +56,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        User::observe(UserObserver::class);
+
         Paginator::useBootstrapFive();
 
         Http::macro('wynn', function () {

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -14,10 +14,10 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
-            'id'            => Str::uuid()->toString(),
-            'username'      => $this->faker->userName(),
-            'account_type'  => AccountType::NORMAL,
-            'auth_token'    => Str::uuid()->toString(),
+            'id' => Str::uuid()->toString(),
+            'username' => 'user_'.Str::random(8),
+            'account_type' => AccountType::NORMAL,
+            'auth_token' => Str::uuid()->toString(),
             'cosmetic_info' => [],
         ];
     }

--- a/tests/Feature/CapeManagerCacheTest.php
+++ b/tests/Feature/CapeManagerCacheTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Http\Libraries\CapeManager;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
+
+uses(Tests\TestCase::class);
+
+beforeEach(function () {
+    Storage::fake('approved');
+    Storage::fake('special');
+});
+
+it('caches the cape base64 result with a 30-day TTL', function () {
+    Storage::disk('approved')->put('sha1hash', 'raw_image_data');
+
+    Cache::spy();
+
+    CapeManager::instance()->getCapeAsBase64('sha1hash', true);
+
+    Cache::shouldHaveReceived('remember')
+        ->withArgs(fn ($key, $ttl) => $key === 'cape-texture-sha1hash-1' && $ttl === 2592000)
+        ->once();
+});
+
+it('uses a different cache key for omitDefaultCape false', function () {
+    Storage::disk('approved')->put('sha1hash', 'raw_image_data');
+    Storage::disk('special')->put('defaultCape', 'default_data');
+
+    Cache::spy();
+
+    CapeManager::instance()->getCapeAsBase64('sha1hash', false);
+
+    Cache::shouldHaveReceived('remember')
+        ->withArgs(fn ($key, $ttl) => $key === 'cape-texture-sha1hash-0' && $ttl === 2592000)
+        ->once();
+});
+
+it('does not cache results on special dates', function () {
+    $manager = Mockery::mock(CapeManager::class)->makePartial();
+    $manager->shouldReceive('isSpecialDate')->andReturn(true);
+    $manager->shouldReceive('getSpecialCape')->andReturn('special_data');
+
+    Cache::spy();
+
+    $manager->getCapeAsBase64('sha1hash', true);
+
+    Cache::shouldNotHaveReceived('remember');
+});

--- a/tests/Feature/CapeManagerCacheTest.php
+++ b/tests/Feature/CapeManagerCacheTest.php
@@ -11,6 +11,12 @@ beforeEach(function () {
     Storage::fake('special');
 });
 
+afterEach(function () {
+    $reflection = new ReflectionProperty(CapeManager::class, 'instance');
+    $reflection->setAccessible(true);
+    $reflection->setValue(null, null);
+});
+
 it('caches the cape base64 result with a 30-day TTL', function () {
     Storage::disk('approved')->put('sha1hash', 'raw_image_data');
 

--- a/tests/Feature/ResourceSchemaTest.php
+++ b/tests/Feature/ResourceSchemaTest.php
@@ -18,8 +18,14 @@ class ResourceSchemaTest extends TestCase
         $user->id = '00000000-0000-0000-0000-000000000001';
 
         Cache::shouldReceive('remember')
+            ->with('user-00000000-0000-0000-0000-000000000001', \Mockery::any(), \Mockery::any())
             ->once()
             ->andReturn($user);
+
+        Cache::shouldReceive('remember')
+            ->with(\Mockery::on(fn ($key) => str_starts_with($key, 'cape-texture-')), \Mockery::any(), \Mockery::any())
+            ->zeroOrMoreTimes()
+            ->andReturn(null);
 
         $response = $this->withHeaders([
             'User-Agent' => 'Wynntils Artemis Test',

--- a/tests/Feature/UserControllerETagTest.php
+++ b/tests/Feature/UserControllerETagTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use App\Http\Middleware\BlockNonWynntilsUserAgents;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(Tests\TestCase::class, RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->withoutMiddleware(BlockNonWynntilsUserAgents::class);
+});
+
+it('returns an ETag header with a successful user info response', function () {
+    $user = User::factory()->create();
+
+    $this->postJson('/user/getInfo', ['uuid' => $user->id])
+        ->assertOk()
+        ->assertHeader('ETag');
+});
+
+it('returns 304 when If-None-Match matches the current ETag', function () {
+    $user = User::factory()->create();
+
+    $etag = md5($user->account_type->value.json_encode($user->cosmetic_info));
+
+    $this->withHeaders(['If-None-Match' => $etag])
+        ->postJson('/user/getInfo', ['uuid' => $user->id])
+        ->assertStatus(304);
+});
+
+it('returns 200 with ETag header when If-None-Match is stale', function () {
+    $user = User::factory()->create();
+
+    $this->withHeaders(['If-None-Match' => 'outdated-etag'])
+        ->postJson('/user/getInfo', ['uuid' => $user->id])
+        ->assertOk()
+        ->assertHeader('ETag');
+});
+
+it('returns 200 with ETag header when If-None-Match is absent', function () {
+    $user = User::factory()->create();
+
+    $this->postJson('/user/getInfo', ['uuid' => $user->id])
+        ->assertOk()
+        ->assertHeader('ETag');
+});
+
+it('returns a new ETag after cosmetic_info changes', function () {
+    $user = User::factory()->create(['cosmetic_info' => ['capeTexture' => 'abc']]);
+
+    $first = $this->postJson('/user/getInfo', ['uuid' => $user->id]);
+    $firstEtag = $first->headers->get('ETag');
+
+    $user->cosmetic_info = ['capeTexture' => 'xyz'];
+    $user->save();
+
+    $second = $this->postJson('/user/getInfo', ['uuid' => $user->id]);
+    $secondEtag = $second->headers->get('ETag');
+
+    expect($firstEtag)->not->toBe($secondEtag);
+});

--- a/tests/Feature/UserControllerETagTest.php
+++ b/tests/Feature/UserControllerETagTest.php
@@ -21,7 +21,7 @@ it('returns an ETag header with a successful user info response', function () {
 it('returns 304 when If-None-Match matches the current ETag', function () {
     $user = User::factory()->create();
 
-    $etag = md5($user->account_type->value.json_encode($user->cosmetic_info));
+    $etag = '"'.md5($user->account_type->value.json_encode($user->cosmetic_info)).'"';
 
     $this->withHeaders(['If-None-Match' => $etag])
         ->postJson('/user/getInfo', ['uuid' => $user->id])

--- a/tests/Feature/UserObserverTest.php
+++ b/tests/Feature/UserObserverTest.php
@@ -49,3 +49,14 @@ it('does not clear caches when unrelated fields change', function () {
 
     expect(Cache::has("user-{$user->id}"))->toBeTrue();
 });
+
+it('does not clear cape texture cache when only account_type changes', function () {
+    $texture = 'abc123';
+    $user = User::factory()->create(['cosmetic_info' => ['capeTexture' => $texture]]);
+    Cache::put("cape-texture-{$texture}-1", 'base64data', 2592000);
+
+    $user->account_type = AccountType::DONATOR;
+    $user->save();
+
+    expect(Cache::has("cape-texture-{$texture}-1"))->toBeTrue();
+});

--- a/tests/Feature/UserObserverTest.php
+++ b/tests/Feature/UserObserverTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Enums\AccountType;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+
+uses(Tests\TestCase::class, RefreshDatabase::class);
+
+it('clears the user model cache when account_type changes', function () {
+    $user = User::factory()->create();
+    Cache::put("user-{$user->id}", $user, 3600);
+
+    $user->account_type = AccountType::DONATOR;
+    $user->save();
+
+    expect(Cache::has("user-{$user->id}"))->toBeFalse();
+});
+
+it('clears the user model cache when cosmetic_info changes', function () {
+    $user = User::factory()->create(['cosmetic_info' => ['capeTexture' => 'abc123']]);
+    Cache::put("user-{$user->id}", $user, 3600);
+
+    $user->cosmetic_info = ['capeTexture' => 'def456'];
+    $user->save();
+
+    expect(Cache::has("user-{$user->id}"))->toBeFalse();
+});
+
+it('clears the old cape texture cache keys when cosmetic_info changes', function () {
+    $oldTexture = 'abc123';
+    $user = User::factory()->create(['cosmetic_info' => ['capeTexture' => $oldTexture]]);
+    Cache::put("cape-texture-{$oldTexture}-1", 'base64data', 2592000);
+    Cache::put("cape-texture-{$oldTexture}-0", 'base64data', 2592000);
+
+    $user->cosmetic_info = ['capeTexture' => 'def456'];
+    $user->save();
+
+    expect(Cache::has("cape-texture-{$oldTexture}-1"))->toBeFalse()
+        ->and(Cache::has("cape-texture-{$oldTexture}-0"))->toBeFalse();
+});
+
+it('does not clear caches when unrelated fields change', function () {
+    $user = User::factory()->create();
+    Cache::put("user-{$user->id}", $user, 3600);
+
+    $user->username = 'new_username';
+    $user->save();
+
+    expect(Cache::has("user-{$user->id}"))->toBeTrue();
+});


### PR DESCRIPTION
## Summary

- **UserObserver**: clears `user-{uuid}` and `cape-texture-*` cache keys via event-driven invalidation when `account_type` or `cosmetic_info` changes — replaces TTL-only freshness with precise invalidation since all writes go through Athena
- **CapeManager texture cache**: wraps the disk read + base64 encode in a 30-day `Cache::remember`; also clears texture cache on `approveCape`/`banCape`; eliminates the most expensive per-request operation on the highest-traffic route
- **ETag support on `getInfoPost`**: returns RFC 7232-compliant `ETag` header and `304 Not Modified` when `If-None-Match` matches, allowing Wynntils clients to skip re-downloading unchanged user data; user model cache TTL extended from 600s to 3600s

## Test Plan

- [ ] 13 new Pest tests added across `UserObserverTest`, `CapeManagerCacheTest`, `UserControllerETagTest`
- [ ] Run `vendor/bin/sail artisan test --compact` — 34 pass, 1 pre-existing failure in `VersionControllerTest` (requires seeded version data, unrelated to this change)
- [ ] Verify `POST /user/getInfo` returns an `ETag` header on first request
- [ ] Verify `POST /user/getInfo` returns `304` when `If-None-Match` matches the ETag
- [ ] Verify updating a user's cosmetic_info invalidates their cache and returns a new ETag on the next request