### PR TITLE
fix: empty arrays in item weights

### DIFF
--- a/app/Http/Libraries/Requests/Cache/ItemWeights.php
+++ b/app/Http/Libraries/Requests/Cache/ItemWeights.php
@@ -91,10 +91,10 @@ class ItemWeights
     private function removeEmptyArrays(array $data): array
     {
         foreach ($data as $key => $value) {
-            if(is_array($value)) {
+            if (is_array($value)) {
                 $value = $this->removeEmptyArrays($value);
 
-                if($value === []) {
+                if ($value === []) {
                     unset($data[$key]);
                 }
             }

--- a/app/Http/Libraries/Requests/Cache/ItemWeights.php
+++ b/app/Http/Libraries/Requests/Cache/ItemWeights.php
@@ -68,7 +68,7 @@ class ItemWeights
             $out[$item][$weightName] = $weight['identifications'];
         }
 
-        return $out;
+        return $this->removeEmptyArrays($out);
     }
 
     private function scaledWeights(array $data): array
@@ -85,6 +85,21 @@ class ItemWeights
             }
         });
 
-        return $out;
+        return $this->removeEmptyArrays($out);
+    }
+
+    private function removeEmptyArrays(array $data): array
+    {
+        foreach ($data as $key => $value) {
+            if(is_array($value)) {
+                $value = $this->removeEmptyArrays($value);
+
+                if($value === []) {
+                    unset($data[$key]);
+                }
+            }
+        }
+
+        return $data;
     }
 }


### PR DESCRIPTION
Wynntils doesn't know what to do with empty arrays, there is no need to have empty arrays either for weights so they are removed here.